### PR TITLE
Fixed fatal error by adding a check for product existence before call…

### DIFF
--- a/includes/helpers/woocommerce/template-product-loop.php
+++ b/includes/helpers/woocommerce/template-product-loop.php
@@ -1154,16 +1154,15 @@ class Templaza_Product_Loop {
 	 */
 	public function product_variable_add_to_cart_text( $text ) {
 		global $product;
-
-		if ( ! $product->is_type( 'variable' ) ) {
+	
+		if ( ! isset( $product ) || ! is_a( $product, 'WC_Product' ) || ! $product->is_type( 'variable' ) ) {
 			return $text;
 		}
-
+	
 		if ( $product->is_purchasable() ) {
 			$text = esc_html__( 'Add to cart', 'templaza-framework' );
-
 		}
-
+	
 		return $text;
 	}
 


### PR DESCRIPTION
Fixes fatal error caused by calling is_type() method on undefined product object. Added a check to ensure the existence of the product object before calling is_type() method in order to prevent the error. This resolves the issue encountered on the WooCommerce cart page.